### PR TITLE
fix: monitor for active text editor change events

### DIFF
--- a/client/matching/matchWord.js
+++ b/client/matching/matchWord.js
@@ -70,7 +70,7 @@ function matchWords(lineText, lineNum, uri) {
  * Iterates thru all matchers to try to find a match, short circuits early if a match is made  
  */
 function match(context) {
-  if (!context.word || context.word.value === 'null' || context.word.value.length <= 1) { // Also ignore null and single character words
+  if (!context.word || context.word.value === 'null') { // Also ignore null
     return response(); 
   }
 

--- a/client/runescript-language.js
+++ b/client/runescript-language.js
@@ -24,6 +24,7 @@ function activate(context) {
     vscode.workspace.createFileSystemWatcher('**/.git/HEAD').onDidCreate(() => vscode.commands.executeCommand(commands.rebuildCache.id));
     vscode.workspace.onDidSaveTextDocument(saveDocumentEvent => cacheManager.rebuildFile(saveDocumentEvent.uri));
     vscode.workspace.onDidChangeTextDocument(() => cacheManager.rebuildActiveFile());
+    vscode.window.onDidChangeActiveTextEditor(() => cacheManager.rebuildActiveFile());
     vscode.workspace.onDidDeleteFiles(filesDeletedEvent => cacheManager.clearFiles(filesDeletedEvent.files));
     vscode.workspace.onDidRenameFiles(filesRenamedEvent => cacheManager.renameFiles(filesRenamedEvent.files));
     vscode.workspace.onDidCreateFiles(filesCreatedEvent => cacheManager.createFiles(filesCreatedEvent.files));


### PR DESCRIPTION
without this event handler, then local variables don't get matched correctly on opening a new text document